### PR TITLE
get_tracks.py can now search by artist name

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -13,7 +13,7 @@ var timeLeft = 1800;
 var score = 0;
 
 // How many points the player can attain
-var maxScore = QUESTIONS.length;
+var maxScore = QUESTIONS.length -1;
 
 // The interval ID for the game's timer
 // (set by startGame, cleared by endGame)
@@ -33,6 +33,7 @@ window.addEventListener("load", (event) => {
     // display the game title and author
     var title = document.getElementById("game-title");
     title.innerHTML = "<h2>" + GAME_METADATA.name + "</h2> by <a href='" + GAME_METADATA.url + "'>" + GAME_METADATA.author + "</a>";
+    gameTimer.innerText = "TIME LEFT: 30:00, SCORE: " + score.toString() + "/" + maxScore.toString();
 });
 
 function startGame() {

--- a/src/index.html
+++ b/src/index.html
@@ -98,7 +98,7 @@
         <ul>
             <li>For each band/artist listed, name one of their songs, <em>except</em> their most popular.</li>
             <li>You get 30 minutes to answer.</li>
-            <li>Capitalization, punctuation and parentheticals don't matter - if the song is named "C.Y.D.T.T. (Can You Dance To This?)", "cydtt" is a valid answer.</li>
+            <li>Capitals, punctuation, and brackets don't matter - if the song is named "C.Y.D.T.T. (Can You Dance To This?)", "cydtt" is a valid answer.</li>
             <li>Tracks where <a href="https://musicbrainz.org/">MusicBrainz</a> lists the band/artist as main author(s) (as of January 31st 2025) qualify.</li>
         </ul>
     </div>
@@ -108,7 +108,7 @@
 
     <input type="button" class="start-game" id="start-game-btn" value="Let's go!" />
     <input type="button" class="forfeit-game" id="forfeit-game-btn" disabled value="I give up!" />
-    <h3 id="game-timer" style="visibility: hidden;">TIME LEFT: 30:00, SCORE: 0/40</h3>
+    <h3 id="game-timer" style="visibility: hidden;">TIME LEFT: 30:00, SCORE: 0/0</h3>
     <table id="game-table" style="visibility: hidden;">
         <tbody>
             <tr>

--- a/utils/get_tracks.py
+++ b/utils/get_tracks.py
@@ -131,9 +131,10 @@ titles_deduplicated = []
 
 for title in titles_processed:
     clean_title = re.sub(r'[^\w]', '', title.lower())
-    if clean_title not in checked:
-        checked.append(clean_title)
-        titles_deduplicated.append(title)
+    if ((not clean_title.isspace()) and (clean_title)):
+        if clean_title not in checked:
+            checked.append(clean_title)
+            titles_deduplicated.append(title)
 
 
 print(titles_deduplicated)

--- a/utils/get_tracks.py
+++ b/utils/get_tracks.py
@@ -6,27 +6,109 @@ import musicbrainzngs
 import re
 musicbrainzngs.set_useragent("One-Hit-Quiz Track Retrieval", "1.0.0", "github.com/strangebroadcasts/one-hit-quiz")
 
-print("Look up the artist's MusicBrainz id")
-print("For example, you could look up the Artist Queen: ")
-print("  * via the web: https://musicbrainz.org/search?type=artist&query=queen")
-print("       where you can get the artist ID from the artist's URL")
-print("  * or via the API: https://musicbrainz.org/ws/2/artist?fmt=json&limit=5&query=Queen")
-print("       where you can get the artist ID from the artists->[result number]->id\n")
 
-artist_id = input("Now enter the MusicBrainz artist ID (in hex format, e.g. bcadd123-...) here: ")
+def artist_search():
+    artist_name = input("Search for Artist: ")
+    if len(artist_name.strip()) < 1:
+        print("Exiting.")
+        sys.exit(0)
+
+    limit = 5
+
+    result = musicbrainzngs.search_artists(artist=artist_name, limit=limit)
+    print(str(len(result))+" results")
+    i=1
+    for artist in result['artist-list']:
+        out = str(i) + ": "
+        area = ""
+        span = ""
+        genre_list= ""
+        if 'id' in artist:
+            if "name" in artist:
+                out += artist['name'].ljust(25) +" "
+            if 'type' in artist:
+                out += artist['type'].ljust(8) +" "
+            if 'begin-area' in artist:
+                if 'name' in artist["begin-area"]:
+                    area += artist["begin-area"]["name"][:15] +" "
+            if 'country' in artist:
+                area += artist['country'][:20] +" "
+            out += area.ljust(20) +" "
+            if 'life-span' in artist:
+                if 'begin' in artist["life-span"]:
+                    span += "("+artist["life-span"]["begin"][:4] +" - "
+                if 'ended' in artist["life-span"]:
+                    if (artist["life-span"]["ended"] == "true"):
+                        if 'end' in artist["life-span"]:
+                            span += artist["life-span"]["end"][:4] +")"
+                        else:
+                            span += "?)"
+                    else:
+                        span += "present)"
+                out += span.ljust(17) +" "
+            if 'tag-list' in artist:
+                genres = sorted(artist['tag-list'], key=lambda d: d['count'], reverse=True)
+                if len(genres) >0:
+                    genre_list += genres[0]["name"][:16] + ", "
+                    if len(genres) >1:
+                        genre_list += genres[1]["name"][:16] + ", "
+                    out += genre_list.ljust(34)
+            print(out)
+        i = i+1
+
+    try:
+        artist_number = int(input('Which artist is correct? 1-'+str(limit)+': '))
+        print("Chosen:", result['artist-list'][artist_number-1]["name"], result['artist-list'][artist_number-1]["id"], "\n")
+    except:
+        print("That's not a valid option, please type a number between 1 and "+str(limit))
+        sys.exit(0)
+
+    return result['artist-list'][artist_number-1]["id"]
+
+def mbrainz_id():
+    print("Look up the artist's MusicBrainz id")
+    print("For example, you could look up the Artist Queen: ")
+    print("  * via the web: https://musicbrainz.org/search?type=artist&query=queen")
+    print("       where you can get the artist ID from the artist's URL")
+    print("  * or via the API: https://musicbrainz.org/ws/2/artist?fmt=json&limit=5&query=Queen")
+    print("       where you can get the artist ID from the artists->[result number]->id\n")
+
+    artist_id = input("Now enter the MusicBrainz artist ID (in hex format, e.g. bcadd123-...) here: ")
+    if len(artist_id.strip()) < 1:
+        print("Exiting.")
+        sys.exit(0)
+    return artist_id
+
+print("Would you like to:")
+print("\t 1. Search for a track by artist name")
+print("\t 2. Enter a MusicBrainz ID")
+try:
+    menu = int(input("Select Menu Option (1 or 2): "))
+    if (menu == 1):
+        artist_id = artist_search()
+    elif (menu == 2):
+        artist_id = mbrainz_id()
+
+except:
+    print("That's not a valid option, please type a number.")
+    sys.exit(0)
+
+limit = 5
+
 if len(artist_id.strip()) < 1:
-    print("Exiting.")
+    print("Exiting, artist id error")
     sys.exit(0)
 titles = []
 limit, offset = 25, 0
 recording_count = 10000
 
+print("Searching")
 while offset <= recording_count:
     result = musicbrainzngs.browse_recordings(artist=artist_id, limit=limit, offset=offset)
     recording_list = result.get('recording-list', [])
     recording_count = result.get('recording-count', 0)
     if offset == 0:
-        print("Found ", recording_count, " recordings")
+        print("Found ", recording_count, " recordings. Now getting them:")
     titles += [record['title'] for record in recording_list]
     offset += limit
     remaining = recording_count - offset

--- a/utils/get_tracks.py
+++ b/utils/get_tracks.py
@@ -16,7 +16,6 @@ def artist_search():
     limit = 5
 
     result = musicbrainzngs.search_artists(artist=artist_name, limit=limit)
-    print(str(len(result))+" results")
     i=1
     for artist in result['artist-list']:
         out = str(i) + ": "
@@ -37,6 +36,8 @@ def artist_search():
             if 'life-span' in artist:
                 if 'begin' in artist["life-span"]:
                     span += "("+artist["life-span"]["begin"][:4] +" - "
+                else:
+                    span += "(? - "
                 if 'ended' in artist["life-span"]:
                     if (artist["life-span"]["ended"] == "true"):
                         if 'end' in artist["life-span"]:
@@ -45,6 +46,8 @@ def artist_search():
                             span += "?)"
                     else:
                         span += "present)"
+                else:
+                    span += "?)"
                 out += span.ljust(17) +" "
             if 'tag-list' in artist:
                 genres = sorted(artist['tag-list'], key=lambda d: d['count'], reverse=True)


### PR DESCRIPTION
### Change summary
- Added menu with option to search by name, or enter MusicBrainz ID instead 
    - MusicBrainz ID is still very useful for difficult searches (eg. single-character band names)
- Doesn't list any recordings whose cleaned names are blank or all whitespace.

### Example of search output
```
Would you like to:
         1. Search for a track by artist name
         2. Enter a MusicBrainz ID
Select Menu Option (1 or 2): 1
Search for Artist: queen
1: Queen                     Group    London GB            (1970 - ?)        british, pop rock,                
2: Queen Latifah             Person   Newark US            (1970 - present)  hip hop, jazz,                    
3: Ivy Queen                 Person   Añasco PR            (1972 - present)  latin, latin urban,               
4: Queen + Paul Rodgers      Group    GB                   (2005 - 2009)     symphonic rock,                   
5: Storm Queen               Group    New Jersey US        (? - present)     
Which artist is correct? 1-5: 1
Chosen: Queen 0383dadf-2a4e-4d10-a46a-e9e041da8eb3 

Searching
Found  6517  recordings. Now getting them:
```